### PR TITLE
Remove deprecated mapTestClassNameToCoveredClassName

### DIFF
--- a/Tests/phpunit.xml
+++ b/Tests/phpunit.xml
@@ -7,7 +7,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          printerClass="PHPUnit\TextUI\ResultPrinter"
          processIsolation="false"
          stopOnError="false"


### PR DESCRIPTION
This option should be removed in order the tests to pass