### PR TITLE
Added missing translation in German

### DIFF
--- a/views/admin/de/tcklarna_lang.php
+++ b/views/admin/de/tcklarna_lang.php
@@ -37,6 +37,7 @@ $aLang = array(
     'tcklarna_tbclklarna_orders' => 'Klarna',
     'TCKLARNA_NO_OPTIONS_MODE'   => 'In diesem Modus gibt es keine Einstellungen.',
     'TCKLARNA_CHANGES_SAVED'     => 'Alle Einstellungen wurden gesichert.',
+    'TCKLARNA_EMPTY_FIELDS_WARRNING' => 'Das Leerlassen von URL-Feldern kann zu Fehlfunktionen des Moduls führen.',
 
     'TCKLARNA_EASY'                         => 'So einfach ist es, Klarna zu aktiveren',
     'TCKLARNA_PHONE'                        => 'Telefon',


### PR DESCRIPTION
The key 'TCKLARNA_EMPTY_FIELDS_WARRNING' was not used in German. Added translation.