### PR TITLE
Fix tests for OXID 6.3

### DIFF
--- a/Tests/Unit/Component/KlarnaBasketComponentTest.php
+++ b/Tests/Unit/Component/KlarnaBasketComponentTest.php
@@ -17,7 +17,7 @@ use TopConcepts\Klarna\Tests\Unit\ModuleUnitTestCase;
  */
 class KlarnaBasketComponentTest extends ModuleUnitTestCase {
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
     }
 

--- a/Tests/Unit/Controller/Admin/KlarnaOrderOverviewTest.php
+++ b/Tests/Unit/Controller/Admin/KlarnaOrderOverviewTest.php
@@ -275,7 +275,9 @@ class KlarnaOrderOverviewTest extends ModuleUnitTestCase {
         ];
     }
 
-    public function testIsCredentialsValid() {
+    public function testIsCredentialsValid()
+    {
+        $this->setOrder();
         $controller = $this->getMockBuilder(OrderOverview::class)
             ->setMethods(['getEditObjectId',])
             ->getMock();
@@ -283,7 +285,6 @@ class KlarnaOrderOverviewTest extends ModuleUnitTestCase {
         $result = $controller->isCredentialsValid();
         $this->assertFalse($result);
 
-        $this->setOrder();
         $this->setModuleConfVar('aKlarnaCreds_DE', '');
         $this->setModuleConfVar('sKlarnaMerchantId', 'smid');
         $this->setModuleConfVar('sKlarnaPassword', 'psw');

--- a/Tests/Unit/Controller/KlarnaExpressControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaExpressControllerTest.php
@@ -197,7 +197,7 @@ class KlarnaExpressControllerTest extends ModuleUnitTestCase {
         $oRequest->expects($this->once())->method('getRequestEscapedParameter')->willReturn($sslredirect);
         $kcoController = oxNew(KlarnaExpressController::class);
         $kcoController->checkSsl($oRequest);
-        $this->assertContains((string)$expectedResult, (string)\oxUtilsHelper::$sRedirectUrl);
+        $this->doAssertContains((string)$expectedResult, (string)\oxUtilsHelper::$sRedirectUrl);
     }
 
     public function checkSslDataProvider() {

--- a/Tests/Unit/Controller/KlarnaPaymentControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaPaymentControllerTest.php
@@ -110,7 +110,7 @@ class KlarnaPaymentControllerTest extends ModuleUnitTestCase
     {
         $oPaymentController = oxNew(PaymentController::class);
         $result             = $oPaymentController->removeKlarnaPrefix('Klarna String');
-        $this->assertNotContains('Klarna ', $result);
+        $this->doAssertNotContains('Klarna ', $result);
     }
 
     public function testIncludeKPWidget()

--- a/Tests/Unit/Controller/KlarnaValidationControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaValidationControllerTest.php
@@ -114,7 +114,7 @@ class KlarnaValidationControllerTest extends ModuleUnitTestCase
         $this->assertNotEmpty($result->count());
 
         $this->assertEquals(303, \oxUtilsHelper::$iCode);
-        $this->assertContains('klarnaInvalid=1&MY_ERROR=33&CANT_BUY=10', \oxUtilsHelper::$sRedirectUrl);
+        $this->doAssertContains('klarnaInvalid=1&MY_ERROR=33&CANT_BUY=10', \oxUtilsHelper::$sRedirectUrl);
     }
 
 

--- a/Tests/Unit/Controller/KlarnaValidationControllerTest.php
+++ b/Tests/Unit/Controller/KlarnaValidationControllerTest.php
@@ -18,13 +18,13 @@ use TopConcepts\Klarna\Tests\Unit\ModuleUnitTestCase;
 class KlarnaValidationControllerTest extends ModuleUnitTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setModuleConfVar('blKlarnaLoggingEnabled', true, 'bool');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->setModuleConfVar('blKlarnaLoggingEnabled', false, 'bool');

--- a/Tests/Unit/Core/KlarnaFormatterTest.php
+++ b/Tests/Unit/Core/KlarnaFormatterTest.php
@@ -77,7 +77,7 @@ class KlarnaFormatterTest extends ModuleUnitTestCase
         $result = KlarnaFormatter::klarnaToOxidAddress($addressData, $sKey);
         $sKey === null
             ? $this->assertNull($result)
-            : $this->assertArraySubset($expected, $result);
+            : $this->doAssertArraySubset($expected, $result);
     }
 
     public function klarnaToOxidAddressDataprovider()
@@ -164,5 +164,14 @@ class KlarnaFormatterTest extends ModuleUnitTestCase
             ['92ebae5067055431aeaaa6f75bd9a131', ['41b545c65fe99ca2898614e563a7108a' => 'Gregory Dabrowski, Karnapp 25, 21079 Hamburg']],
             ['c95a1d97acaebd371851727d1173dcd0', false]
         ];
+    }
+
+    protected function doAssertArraySubset($needle, $haystack)
+    {
+        if (method_exists($this, 'assertArraySubsetOxid')) {
+            parent::assertArraySubsetOxid($needle, $haystack);
+        } else {
+            parent::doAssertArraySubset($needle, $haystack);
+        }
     }
 }

--- a/Tests/Unit/Core/KlarnaFormatterTest.php
+++ b/Tests/Unit/Core/KlarnaFormatterTest.php
@@ -171,7 +171,7 @@ class KlarnaFormatterTest extends ModuleUnitTestCase
         if (method_exists($this, 'assertArraySubsetOxid')) {
             parent::assertArraySubsetOxid($needle, $haystack);
         } else {
-            parent::doAssertArraySubset($needle, $haystack);
+            parent::assertArraySubset($needle, $haystack);
         }
     }
 }

--- a/Tests/Unit/Core/KlarnaPaymentTest.php
+++ b/Tests/Unit/Core/KlarnaPaymentTest.php
@@ -148,11 +148,11 @@ class KlarnaPaymentTest extends ModuleUnitTestCase
 
         $oKlarnaOrder = new  KlarnaPayment($oBasket, $oUser, $aPost);
 
-        $this->assertContains($results['controllerName'], $oKlarnaOrder->refreshUrl);
+        $this->doAssertContains($results['controllerName'], $oKlarnaOrder->refreshUrl);
         $this->assertEquals($results['_sPaymentMethod'], $this->getProtectedClassProperty($oKlarnaOrder, '_sPaymentMethod'));
         $this->assertEquals($results['currencyToCountryMatch'], $this->getProtectedClassProperty($oKlarnaOrder, 'currencyToCountryMatch'));
         $this->assertEquals((bool)$results['error'], $oKlarnaOrder->isError());
-        $results['error'] && $this->assertContains($results['error'], $oKlarnaOrder->getError()[0]);
+        $results['error'] && $this->doAssertContains($results['error'], $oKlarnaOrder->getError()[0]);
         $this->assertEquals($results['reauthorizeRequired'], $this->getSessionParam('reauthorizeRequired'));
         $this->assertEquals($results['sessionValid'], $oKlarnaOrder->isSessionValid());
 

--- a/Tests/Unit/Core/KlarnaUtilsTest.php
+++ b/Tests/Unit/Core/KlarnaUtilsTest.php
@@ -49,7 +49,7 @@ class KlarnaUtilsTest extends ModuleUnitTestCase
             ->getMock();
         $item->expects($this->exactly(2))->method('isBundle')->willReturn(false);
         $item->expects($this->once())->method('getUnitPrice')->willReturn($price);
-        $item->expects($this->once())->method('getArticle')->willReturn($article);
+        $item->expects($this->exactly(2))->method('getArticle')->willReturn($article);
         $item->expects($this->once())->method('getRegularUnitPrice')->willReturn($priceUnit);
         $result = KlarnaUtils::calculateOrderAmountsPricesAndTaxes($item, true);
         $expected = [

--- a/Tests/Unit/Model/KlarnaUserPaymentTest.php
+++ b/Tests/Unit/Model/KlarnaUserPaymentTest.php
@@ -27,7 +27,7 @@ class KlarnaUserPaymentTest extends ModuleUnitTestCase
 
         $result = $userPaymentModel->getBadgeUrl();
 
-        $this->assertContains($expectedResult, $result);
+        $this->doAssertContains($expectedResult, $result);
     }
 
     public function paymentDataProvider()

--- a/Tests/Unit/Model/KlarnaUserTest.php
+++ b/Tests/Unit/Model/KlarnaUserTest.php
@@ -23,7 +23,7 @@ use TopConcepts\Klarna\Tests\Unit\ModuleUnitTestCase;
 class KlarnaUserTest extends ModuleUnitTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/Tests/Unit/ModuleUnitTestCase.php
+++ b/Tests/Unit/ModuleUnitTestCase.php
@@ -210,7 +210,7 @@ class ModuleUnitTestCase extends UnitTestCase
 
     protected function doAssertNotContains($needle, $haystack, $message = '')
     {
-        if (method_exists($this, 'assertStringContainsString')) {
+        if (method_exists($this, 'assertStringNotContainsString')) {
             parent::assertStringNotContainsString($needle, $haystack, $message);
         } else {
             parent::assertNotContains($needle, $haystack, $message);

--- a/Tests/Unit/ModuleUnitTestCase.php
+++ b/Tests/Unit/ModuleUnitTestCase.php
@@ -33,7 +33,7 @@ class ModuleUnitTestCase extends UnitTestCase
     /** @var TestConfig  */
     protected $testConfig;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -72,7 +72,7 @@ class ModuleUnitTestCase extends UnitTestCase
         return $url;
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Tests/Unit/ModuleUnitTestCase.php
+++ b/Tests/Unit/ModuleUnitTestCase.php
@@ -199,4 +199,21 @@ class ModuleUnitTestCase extends UnitTestCase
         return $method;
     }
 
+    protected function doAssertContains($needle, $haystack, $message = '')
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            parent::assertStringContainsString($needle, $haystack, $message);
+        } else {
+            parent::assertContains($needle, $haystack, $message);
+        }
+    }
+
+    protected function doAssertNotContains($needle, $haystack, $message = '')
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            parent::assertStringNotContainsString($needle, $haystack, $message);
+        } else {
+            parent::assertNotContains($needle, $haystack, $message);
+        }
+    }
 }


### PR DESCRIPTION
Update tests to be compatible with PHPUnit8 as well as older versions.