### PR TITLE
Stabilize code for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "rmccue/requests": ">=1.0"
+    "rmccue/requests": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "*",


### PR DESCRIPTION
In case communication with Klarna service fails, PaymenHandler::checkFraudStatus() might be called with a boolean but is type hinted array. Without the fix this will lead to fatal error with PHP8 in some edge cases.